### PR TITLE
docs: add installation instructions and skill list to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Claude Code skills collection.
 # List skills in this repository
 npx skills add myuon/agent-skills --list
 
-# Install specific skills
+# Install specific skills (add -g for global installation)
 npx skills add myuon/agent-skills --skill commit --skill gh -y
 
 # Install to specific agents


### PR DESCRIPTION
## Summary
- README にスキル一覧テーブル（commit, create-agent-skills, gh）を追加
- `npx skills add` を使ったインストール方法を記載

## Test plan
- [ ] README の表示を GitHub 上で確認

🤖 Generated with [Claude Code](https://claude.ai/code)