### PR TITLE
docs: add usecases section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ Claude Code skills collection.
 | `create-agent-skills` | 新しい Claude Code スキルを作成するためのガイド |
 | `gh` | GitHub CLI (gh) で Issue・Sub-issue・PR・CI を操作するためのクイックリファレンス |
 
+## Usecases
+
+### 長期的なプロジェクトや開発
+
+Conventional Commits によるコミット管理と GitHub CLI 操作を導入して、開発ワークフローを整える。
+
+```bash
+npx skills add myuon/agent-skills --skill commit --skill gh -g -y
+```
+
+### React Native + Expo を使ったアプリ開発
+
+Expo 公式スキルを追加して、Expo/React Native 固有のベストプラクティスを適用する。
+
+```bash
+npx skills add expo/skills -g -y
+```
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary
- README に Usecases セクションを追加
- 長期プロジェクト向け（commit + gh）と Expo アプリ開発向け（expo/skills）のユースケースを記載

## Test plan
- [ ] GitHub 上で README の表示を確認

🤖 Generated with [Claude Code](https://claude.ai/code)