### PR TITLE
feat(babysit): PR をマージ可能な状態に保つスキルを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Claude Code skills collection.
 
 | Skill | Description |
 |-------|-------------|
+| `babysit` | コメントのトリアージ・コンフリクト解消・CI 修正を繰り返して PR をマージ可能な状態に保つ |
 | `commit` | Conventional Commits に従って git commit を実行 |
 | `create-agent-skills` | 新しい Claude Code スキルを作成するためのガイド |
 | `dispatch` | 複数のイシューを同時に振り分け・実装するワークフロー |

--- a/skills/babysit/SKILL.md
+++ b/skills/babysit/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: babysit
+description: >-
+  Keep a PR merge-ready by triaging comments, resolving clear conflicts, and
+  fixing CI in a loop.
+---
+
+# Babysit PR
+
+Your job is to get this PR to a merge-ready state.
+
+Check PR status, comments, and latest CI and resolve any issues until the PR is ready to merge.
+
+1. Comments: Review every comment (including Bugbot) before acting. Fix only comments you agree with; explain when you disagree or are unsure.
+2. Merge conflicts: When there are conflicts, sync with base branch. Resolve merge conflicts only when intent is clearly the same, otherwise stop and ask for clarification.
+3. CI: Fix CI issues that come up with small scoped fixes. Push them and re-watch CI until mergeable + green + comments triaged.


### PR DESCRIPTION
## 概要

PR を merge-ready な状態に保つための `babysit` スキルを追加します。

## 内容

`skills/babysit/SKILL.md` を新規追加。以下のループで PR をマージ可能な状態へ導きます。

1. **Comments**: Bugbot を含む全コメントを精査。同意できるものだけ修正し、反対・不明な点は説明する。
2. **Merge conflicts**: コンフリクト時は base ブランチと同期。意図が明確に同じ場合のみ解消し、それ以外は止めて確認する。
3. **CI**: CI の問題は小さくスコープを絞った修正で対応。push して mergeable + green + コメント triage 済みになるまで CI を再確認する。

あわせて README のスキル一覧に追記しました。

https://claude.ai/code/session_014x6sSQSGCknAvR22rUVXMS

---
_Generated by [Claude Code](https://claude.ai/code/session_014x6sSQSGCknAvR22rUVXMS)_