### PR TITLE
docs: add ADR skill to README usecases

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Expo 公式スキルを追加して、Expo/React Native 固有のベストプラ
 npx skills add expo/skills -g -y
 ```
 
+### アーキテクチャ上の意思決定を記録する
+
+ADR (Architecture Decision Records) スキルを追加して、設計上の意思決定を構造化されたドキュメントとして残す。
+
+```bash
+npx skills add https://github.com/wshobson/agents --skill architecture-decision-records
+```
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## 概要

Issue #30 に対応し、ADR (Architecture Decision Records) スキルを README に追加しました。

## 変更内容

ADR スキルは外部リポジトリ `wshobson/agents` のものなので、「Skills」テーブル（このリポジトリ内のスキル一覧）ではなく、外部スキルを参照している `expo/skills` と同じ「Usecases」セクションにインストールコマンドを追加しました。

```bash
npx skills add https://github.com/wshobson/agents --skill architecture-decision-records
```

Closes #30

https://claude.ai/code/session_017BaVhPs3iD5VrFtyeX1oDX

---
_Generated by [Claude Code](https://claude.ai/code/session_017BaVhPs3iD5VrFtyeX1oDX)_